### PR TITLE
adds the comment count on the the get article_id endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -98,6 +98,7 @@ describe("News Api Tests", () => {
           body: "I find this existence challenging",
           created_at: "2020-07-09T20:11:00.000Z",
           votes: 100,
+          comment_count: "11",
           article_img_url:
             "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
         };

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -3,7 +3,14 @@ const { getAllArticles } = require('../controllers/articles.controller')
 const { createRef } = require('../db/seeds/utils')
 
 exports.fetchArticleById = (article_id)=>{
-    const queryStatment = 'SELECT * FROM articles WHERE article_id = $1'
+    const queryStatment = `
+    SELECT articles.*, COUNT(comments.article_id) 
+    FROM articles
+    JOIN comments
+    ON articles.article_id = comments.article_id
+    WHERE articles.article_id = $1
+    GROUP BY (articles.article_id);
+    `
     return db
     .query(queryStatment,[article_id])
     .then(({rows})=> {
@@ -14,7 +21,9 @@ exports.fetchArticleById = (article_id)=>{
                 msg: `Article ${article_id} does not exist.`
             })
         }
-          return article
+            article.comment_count = article.count
+            delete article.count
+            return article
         })
 
 }


### PR DESCRIPTION
I am worried I have grossly misunderstood this feature request.

I have assumed that the question means it needs to make use of SQL queries. So my feature now includes the comment count on the GET/ARTICLES/:ARTICLE_ID endpoint instead of say GET/ARTICLES/:ARTICLE_ID?COMMENT_COUNT

In this instance there are no new errors to handle... however, if I am wrong... there are numerous. 

I am constantly paranoid that this is some sneaky trap, I've not seen.... hmmmm...